### PR TITLE
CI troubleshooting related to JINJA_ENVIRONMENT

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 from datetime import datetime
 
-JINJA_EXTENSIONS = ['jinja2.ext.loopcontrols']
+JINJA_ENVIRONMENT = {'extensions': ['jinja2.ext.loopcontrols']}
 
 AUTHOR = 'Efstathia Chioteli, Ioannis Batas'
 SITENAME = 'BALab'

--- a/publishconf.py
+++ b/publishconf.py
@@ -14,7 +14,7 @@ SITEURL = ''
 RELATIVE_URLS = False
 
 FEED_ALL_ATOM = 'feeds/all.atom.xml'
-CATEGORY_FEED_ATOM = 'feeds/%s.atom.xml'
+CATEGORY_FEED_ATOM = 'feeds/{slug}.atom.xml'
 
 DELETE_OUTPUT_DIRECTORY = True
 


### PR DESCRIPTION
Solving KeyError: u'JINJA_ENVIRONMENT':
- Identifying that problem is related with upgrade from pelican 3.7.1 to 4.0.1 and understanding the differences between two versions
- Solving the core problem - Replacing JINJA_EXTENSIONS with JINJA_ENVIRONMENT:  "JINJA_EXTENSIONS has been replaced by the JINJA_ENVIRONMENT setting" and isn't supported anymore
- Replacing %s to {slug}, according to new version: "All settings for slugs now use {slug} and/or {lang} rather than %s"